### PR TITLE
Fix Mixed Content error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ subtitle: Quality Management System adopted by InfoRLife SA in developing softwa
 # When working locally use jekyll serve --baseurl '' so that you can view everything at localhost:4000
 # See http://jekyllrb.com/docs/github-pages/ for more info
 #baseurl: ''
-baseurl: 'http://inforlife.github.io/quality'
+baseurl: 'https://inforlife.github.io/quality'
 
 # Author/Organization info to be displayed in the templates
 author:


### PR DESCRIPTION
This PR fixes the Mixed Content error which doesn't allow assets (CSS, JS, images) to be served. 